### PR TITLE
refactor: avoid using state struct

### DIFF
--- a/cmd/signal/main.go
+++ b/cmd/signal/main.go
@@ -4,47 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/apex/log"
 	"github.com/bassosimone/oonidsl/internal/atomicx"
-	"github.com/bassosimone/oonidsl/internal/model"
 	"github.com/bassosimone/oonidsl/internal/runtimex"
 )
 
-// measurementState contains state variables used when measuring.
-type measurementState struct {
-	// dGen allows to assign unique IDs to submeasurements.
-	idGen *atomicx.Int64
-
-	// logger contains the logger.
-	logger model.Logger
-
-	// tk contains the experiment results.
-	tk *testKeys
-
-	// zeroTime is the "zero time" of the measurement.
-	zeroTime time.Time
-
-	// wg allows waiting for background goroutines.
-	wg *sync.WaitGroup
-}
-
 func main() {
-	state := &measurementState{
-		idGen:    &atomicx.Int64{},
-		logger:   log.Log,
-		tk:       &testKeys{},
-		zeroTime: time.Now(),
-		wg:       &sync.WaitGroup{},
-	}
 	ctx := context.Background()
-
-	err := measure(ctx, state)
+	tk := &testKeys{}
+	err := measure(ctx, log.Log, &atomicx.Int64{}, time.Now(), tk)
 	runtimex.PanicOnError(err, "measure failed unexpectedly")
 
-	data, err := json.Marshal(state.tk)
+	data, err := json.Marshal(tk)
 	runtimex.PanicOnError(err, "json.Marshal failed unexpectedly")
 	fmt.Printf("%s\n", string(data))
 }

--- a/cmd/telegram/main.go
+++ b/cmd/telegram/main.go
@@ -4,47 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/apex/log"
 	"github.com/bassosimone/oonidsl/internal/atomicx"
-	"github.com/bassosimone/oonidsl/internal/model"
 	"github.com/bassosimone/oonidsl/internal/runtimex"
 )
 
-// measurementState contains state variables used when measuring.
-type measurementState struct {
-	// dGen allows to assign unique IDs to submeasurements.
-	idGen *atomicx.Int64
-
-	// logger contains the logger.
-	logger model.Logger
-
-	// tk contains the experiment results.
-	tk *testKeys
-
-	// zeroTime is the "zero time" of the measurement.
-	zeroTime time.Time
-
-	// wg allows waiting for background goroutines.
-	wg *sync.WaitGroup
-}
-
 func main() {
-	state := &measurementState{
-		idGen:    &atomicx.Int64{},
-		logger:   log.Log,
-		tk:       &testKeys{},
-		zeroTime: time.Now(),
-		wg:       &sync.WaitGroup{},
-	}
+	tk := &testKeys{}
 	ctx := context.Background()
 
-	err := measure(ctx, state)
+	err := measure(ctx, log.Log, &atomicx.Int64{}, time.Now(), tk)
 	runtimex.PanicOnError(err, "measure failed unexpectedly")
 
-	data, err := json.Marshal(state.tk)
+	data, err := json.Marshal(tk)
 	runtimex.PanicOnError(err, "json.Marshal failed unexpectedly")
 	fmt.Printf("%s\n", string(data))
 }

--- a/cmd/telegram/measure.go
+++ b/cmd/telegram/measure.go
@@ -4,20 +4,35 @@ package main
 // Top-level measurement algorithm
 //
 
-import "context"
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/bassosimone/oonidsl/internal/atomicx"
+	"github.com/bassosimone/oonidsl/internal/model"
+)
 
 // measure is the top-level measurement algorithm.
-func measure(ctx context.Context, state *measurementState) error {
+func measure(
+	ctx context.Context,
+	logger model.Logger,
+	idGen *atomicx.Int64,
+	zeroTime time.Time,
+	tk *testKeys,
+) error {
+	wg := &sync.WaitGroup{}
+
 	// run DCs measurements in background
-	state.wg.Add(1)
-	go measureDCs(ctx, state)
+	wg.Add(1)
+	go measureDCs(ctx, logger, idGen, zeroTime, tk, wg)
 
 	// run web measurements in background
-	state.wg.Add(1)
-	go measureWeb(ctx, state)
+	wg.Add(1)
+	go measureWeb(ctx, logger, idGen, zeroTime, tk, wg)
 
 	// wait for measurements to terminate
-	state.wg.Wait()
+	wg.Wait()
 
 	// make sure we fail the measurement if the main
 	// context is cancelled (e.g., because the user


### PR DESCRIPTION
I think it's better for each function to only take the arguments
it needs, which paints a better picture of what is used.